### PR TITLE
Initial PDF-to-Quiz App Scaffold

### DIFF
--- a/app/api/generate-quiz/route.ts
+++ b/app/api/generate-quiz/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import OpenAI from "openai";
+import { QuizQuestion } from "@/types/quiz";
+import { generateNumQuestions } from "@/lib/utils";
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+export async function POST(req: NextRequest) {
+  const { text } = await req.json();
+  const wordCount: number = text.split(" ").length;
+  const numQuestions = generateNumQuestions(wordCount);
+
+  const prompt = `Based on the following content, generate ${numQuestions} multiple choice questions. Each should include:
+  - A clear question
+  - 4 answer choices (A, B, C, D)
+  - The correct answer (as letter)
+  - A 1-2 sentence explanation
+
+Content:
+${text}`;
+
+  const completion = await openai.chat.completions.create({
+    model: "gpt-4",
+    messages: [
+      { role: "system", content: "You are a quiz generator AI." },
+      { role: "user", content: prompt },
+    ],
+    temperature: 0.7,
+  });
+
+  const quiz: QuizQuestion[] = JSON.parse(
+    completion.choices[0].message.content || "[]"
+  );
+
+  return NextResponse.json({ quiz });
+}

--- a/app/api/parse-pdf/route.ts
+++ b/app/api/parse-pdf/route.ts
@@ -1,0 +1,10 @@
+import { extractTextFromPDF } from "@/lib/parsePdf";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const file = formData.get("file") as File;
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const text = await extractTextFromPDF(buffer);
+  return NextResponse.json({ text });
+}

--- a/lib/parsePdf.ts
+++ b/lib/parsePdf.ts
@@ -1,0 +1,6 @@
+import pdfParse from "pdf-parse";
+
+export async function extractTextFromPDF(fileBuffer: Buffer): Promise<string> {
+  const data = await pdfParse(fileBuffer);
+  return data.text;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,6 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function numQuestions(wordCound: number) {
+export function generateNumQuestions(wordCound: number) {
   return Math.floor(wordCound / 300);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.525.0",
         "next": "15.3.5",
+        "openai": "^5.8.2",
+        "pdf-parse": "^1.1.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.3.1"
@@ -20,6 +22,7 @@
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/pdf-parse": "^1.1.5",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -1307,6 +1310,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -4644,7 +4657,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4770,6 +4782,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4893,6 +4911,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/openai": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.8.2.tgz",
+      "integrity": "sha512-8C+nzoHYgyYOXhHGN6r0fcb4SznuEn1R7YZMvlqDbnCuE0FM2mm3T1HiYW6WIcMS/F1Of2up/cSPjLPaWt0X9Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5000,6 +5039,28 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.525.0",
     "next": "15.3.5",
+    "openai": "^5.8.2",
+    "pdf-parse": "^1.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.1"
@@ -21,6 +23,7 @@
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/pdf-parse": "^1.1.5",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/types/quiz.ts
+++ b/types/quiz.ts
@@ -1,0 +1,6 @@
+export type QuizQuestion = {
+  question: string;
+  choices: string[];
+  correctAnswer: string;
+  explanation: string;
+};


### PR DESCRIPTION
What's Included
🧠 Core Features
PDF upload via UploadForm

PDF text extraction with pdf-parse

Quiz generation using OpenAI's gpt-4 via @ai-sdk

Basic dynamic quiz question count based on PDF word count

🧩 Component & API Structure
app/page.tsx: homepage with file upload form

components/UploadForm.tsx: handles file input and triggers backend flow

lib/parsePdf.ts: extracts raw text from uploaded PDF

types/quiz.ts: type definition for quiz question object

api/parse-pdf/route.ts: processes uploaded PDF and returns text

api/generate-quiz/route.ts: sends prompt to OpenAI and returns quiz

💄 UI/UX
Integrated shadcn/ui components (Button, Input) in UploadForm

🛠 How it Works
User uploads a PDF

Server extracts text and calculates word count

Server sends text to OpenAI with a quiz prompt

Quiz is returned, stored in sessionStorage, and redirects user to /quiz

🔮 Next Up
Build /quiz page with shadcn UI: quiz rendering + scoring logic

Add results page with answer key + explanations

"Reset Quiz" and "Try Another PDF" CTA buttons